### PR TITLE
Potential fix for code scanning alert no. 7: Unused import

### DIFF
--- a/sources/test_manager_download.py
+++ b/sources/test_manager_download.py
@@ -20,7 +20,7 @@ os.environ["INPUT_SHOW_MASKED_TIME"] = "false"
 os.environ["INPUT_SYMBOL_VERSION"] = "1"
 
 # Now we can safely import the modules
-from manager_download import GITHUB_API_QUERIES, DownloadManager, init_download_manager
+from manager_download import DownloadManager, init_download_manager
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Potential fix for [https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/7](https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/7)

To fix the problem, we need to remove the unused import `GITHUB_API_QUERIES` from the import statement on line 23. This will clean up the code and remove the unnecessary dependency.

- Locate the import statement on line 23 in the file `sources/test_manager_download.py`.
- Remove `GITHUB_API_QUERIES` from the import statement.
- Ensure that the remaining imports in the statement are still correctly formatted and used in the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
