### PR TITLE
Potential fix for code scanning alert no. 6: Unused import

### DIFF
--- a/sources/test_manager_download.py
+++ b/sources/test_manager_download.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import yaml
-from httpx import AsyncClient, Response
+from httpx import Response
 
 # Mock environment variables before importing the modules
 os.environ["INPUT_GH_TOKEN"] = "mock_gh_token"


### PR DESCRIPTION
Potential fix for [https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/6](https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/6)

To fix the problem, we need to remove the unused import statement for `AsyncClient` from the `httpx` library. This will clean up the code and remove unnecessary dependencies, making the code easier to read and maintain.

- Locate the import statement `from httpx import AsyncClient, Response` on line 8.
- Remove `AsyncClient` from the import statement, leaving only `Response` if it is used elsewhere in the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
