### PR TITLE
Potential fix for code scanning alert no. 5: Unused import

### DIFF
--- a/sources/test_manager_download.py
+++ b/sources/test_manager_download.py
@@ -1,7 +1,7 @@
 import json
 import os
 from typing import Dict
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import yaml


### PR DESCRIPTION
Potential fix for [https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/5](https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/5)

To fix the problem, we need to remove the unused import of `Mock` from the `unittest.mock` module. This will clean up the code and remove unnecessary dependencies, making the code easier to read and maintain.

- Locate the import statement on line 4.
- Remove `Mock` from the import statement, leaving only the used imports `AsyncMock` and `patch`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
