### PR TITLE
Potential fix for code scanning alert no. 4: Unused import

### DIFF
--- a/sources/test_manager_download.py
+++ b/sources/test_manager_download.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest


### PR DESCRIPTION
Potential fix for [https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/4](https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/4)

To fix the problem, we need to remove the unused import statement. This will clean up the code and remove the unnecessary dependency. The best way to fix this is to delete the line `from typing import Dict` from the file `sources/test_manager_download.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
