### PR TITLE
Potential fix for code scanning alert no. 3: Unused import

### DIFF
--- a/sources/test_manager_download.py
+++ b/sources/test_manager_download.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import Dict
 from unittest.mock import AsyncMock, Mock, patch


### PR DESCRIPTION
Potential fix for [https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/3](https://github.com/ImBIOS/waka-readme-stats/security/code-scanning/3)

To fix the problem, we need to remove the unused import statement for the `json` module. This will clean up the code and remove the unnecessary dependency. The best way to fix this is to delete the import statement on line 1. No other changes are needed as the `json` module is not used anywhere in the provided code snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
